### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -15,30 +15,30 @@ Cytron_PS2Shield	KEYWORD1
 begin	KEYWORD2
 getValue	KEYWORD2
 getAll	KEYWORD2
-vibrate KEYWORD2
-reset KEYWORD2
-ps_data KEYWORD2
-SERIAL_ERR  KEYWORD2
+vibrate	KEYWORD2
+reset	KEYWORD2
+ps_data	KEYWORD2
+SERIAL_ERR	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-p_select 	LITERAL1
-p_joyl 	 	LITERAL1
-p_joyr 		LITERAL1
-p_start 	LITERAL1
-p_up		LITERAL1
-p_right 	LITERAL1
-p_down		LITERAL1
-p_left		LITERAL1
-p_l2		LITERAL1
-p_r2		LITERAL1
-p_l1		LITERAL1
-p_r1		LITERAL1
+p_select	LITERAL1
+p_joyl	LITERAL1
+p_joyr	LITERAL1
+p_start	LITERAL1
+p_up	LITERAL1
+p_right	LITERAL1
+p_down	LITERAL1
+p_left	LITERAL1
+p_l2	LITERAL1
+p_r2	LITERAL1
+p_l1	LITERAL1
+p_r1	LITERAL1
 p_triangle	LITERAL1
 p_circle	LITERAL1
-p_cross		LITERAL1
+p_cross	LITERAL1
 p_square	LITERAL1
 p_joy_lx	LITERAL1
 p_joy_ly	LITERAL1
@@ -54,6 +54,6 @@ p_joy_rl	LITERAL1
 p_joy_rr	LITERAL1
 
 p_con_status	LITERAL1
-p_motor1		LITERAL1
-p_motor2		LITERAL1
-p_btn_joy		LITERAL1
+p_motor1	LITERAL1
+p_motor2	LITERAL1
+p_btn_joy	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords